### PR TITLE
Add minimum length error to dym. gen. strings

### DIFF
--- a/mmgotool/commands/i18n.go
+++ b/mmgotool/commands/i18n.go
@@ -201,6 +201,7 @@ func checkCmdF(command *cobra.Command, args []string) error {
 }
 
 func addDynamicallyGeneratedStrings(i18nStrings *map[string]bool) {
+	(*i18nStrings)["model.user.is_valid.pwd.app_error"] = true
 	(*i18nStrings)["model.user.is_valid.pwd_lowercase.app_error"] = true
 	(*i18nStrings)["model.user.is_valid.pwd_lowercase_number.app_error"] = true
 	(*i18nStrings)["model.user.is_valid.pwd_lowercase_number_symbol.app_error"] = true


### PR DESCRIPTION
This adds the default case of password check function (min. length) to the dynamically generated string array:

https://github.com/mattermost/mattermost-server/blob/b21767c9a6fbbea9fa37940d2753e08f3ab397dd/utils/password.go#L14

Currently this is blocking the following PR https://github.com/mattermost/mattermost-server/pull/10844 where it's triggered since I've removed an unused password check function.