### PR TITLE
Added agenda plugin to labels mapping list

### DIFF
--- a/labels/mapping.go
+++ b/labels/mapping.go
@@ -6,6 +6,7 @@ var pluginLabels = MergeLabels(coreLabels, issue, helpWanted, docs, plugin)
 
 var defaultMapping = map[string][]Label{
 	"mattermost-oembed-plugin":            pluginLabels,
+	"mattermost-plugin-agenda":            pluginLabels,
 	"mattermost-plugin-antivirus":         pluginLabels,
 	"mattermost-plugin-autolink":          pluginLabels,
 	"mattermost-plugin-aws-SNS":           pluginLabels,


### PR DESCRIPTION
#### Summary

Added new repo for [Agenda Plugin](https://github.com/mattermost/mattermost-plugin-agenda) to label mapping list.
