### PR TITLE
Warn about untracked labels

### DIFF
--- a/labels/label.go
+++ b/labels/label.go
@@ -20,6 +20,13 @@ func (l Label) ToGithubLabel() *github.Label {
 	}
 }
 
+// Equal compare to a github library compatible type
+func (l Label) Equal(gh *github.Label) bool {
+	return gh.GetName() == l.Name &&
+		gh.GetDescription() == l.Description &&
+		gh.GetColor() == l.Color
+}
+
 // MergeLabels return the union of two slices of labels
 func MergeLabels(l1 []Label, l2 ...[]Label) []Label {
 	for _, l := range l2 {

--- a/labels/main.go
+++ b/labels/main.go
@@ -105,9 +105,7 @@ func createOrUpdateLabels(client *github.Client, repo string, labels []Label) {
 
 		for _, remoteLabel := range remoteLabels {
 			if strings.EqualFold(remoteLabel.GetName(), label.Name) {
-				if remoteLabel.GetName() != label.Name ||
-					remoteLabel.GetDescription() != label.Description ||
-					remoteLabel.GetColor() != label.Color {
+				if !label.Equal(remoteLabel) {
 					_, _, err = client.Issues.EditLabel(context.Background(), org, repo, label.Name, label.ToGithubLabel())
 					if err != nil {
 						logger.WithError(err).Error("Failed to edit label")
@@ -132,6 +130,21 @@ func createOrUpdateLabels(client *github.Client, repo string, labels []Label) {
 
 			logger.Info("Created label")
 		}
+	}
+
+	for _, remoteLabel := range remoteLabels {
+		found := false
+		for _, label := range labels {
+			if label.Equal(remoteLabel) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			log.WithFields(log.Fields{"label": remoteLabel.GetName(), "repo": repo}).Warn("found untracked label")
+		}
+
 	}
 }
 


### PR DESCRIPTION
#### Summary
This helps tracking down which repos use "custom" labels and work on migrating them into the mapping list.