### PR TITLE
Add clean empty translations command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "./node_modules/eslint-config-mattermost/.eslintrc.json"
+    "./node_modules/eslint-config-mattermost/configs/.eslintrc.json"
   ],
   "plugins": [
     "import"

--- a/mmgotool/commands/i18n.go
+++ b/mmgotool/commands/i18n.go
@@ -12,7 +12,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -55,20 +54,12 @@ var CheckCmd = &cobra.Command{
 	RunE:    checkCmdF,
 }
 
-var CleanCmd = &cobra.Command{
-	Use:     "clean",
+var CleanEmptyCmd = &cobra.Command{
+	Use:     "clean-empty",
 	Short:   "Clean empty translations",
 	Long:    "Clean empty translations in translation files other than i18n/en.json base file",
-	Example: "  i18n clean",
-	RunE:    cleanCmdF,
-}
-
-var CleanAllCmd = &cobra.Command{
-	Use:     "clean-all",
-	Short:   "Clean all empty translations",
-	Long:    "Clean all empty translations in translation files other than i18n/en.json base file",
-	Example: "  i18n clean-all",
-	RunE:    cleanAllCmdF,
+	Example: "  i18n clean-empty",
+	RunE:    cleanEmptyCmdF,
 }
 
 func init() {
@@ -83,24 +74,16 @@ func init() {
 	CheckCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
 	CheckCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
 
-	CleanCmd.Flags().Bool("dry-run", false, "Run without applying changes")
-	CleanCmd.Flags().Bool("check", false, "Throw exit code on empty translation strings")
-	CleanCmd.Flags().String("file", "de.json", "Filename, e.g. de.json, to clean empty translation strings from")
-	CleanCmd.Flags().String("portal-dir", "../customer-web-server", "Path to folder with the Mattermost Customer Portal source code")
-	CleanCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
-	CleanCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
-
-	CleanAllCmd.Flags().Bool("dry-run", false, "Run without applying changes")
-	CleanAllCmd.Flags().Bool("check", false, "Throw exit code on empty translation strings")
-	CleanAllCmd.Flags().String("portal-dir", "../customer-web-server", "Path to folder with the Mattermost Customer Portal source code")
-	CleanAllCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
-	CleanAllCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
+	CleanEmptyCmd.Flags().Bool("dry-run", false, "Run without applying changes")
+	CleanEmptyCmd.Flags().Bool("check", false, "Throw exit code on empty translation strings")
+	CleanEmptyCmd.Flags().String("portal-dir", "../customer-web-server", "Path to folder with the Mattermost Customer Portal source code")
+	CleanEmptyCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
+	CleanEmptyCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
 
 	I18nCmd.AddCommand(
 		ExtractCmd,
 		CheckCmd,
-		CleanCmd,
-		CleanAllCmd,
+		CleanEmptyCmd,
 	)
 	RootCmd.AddCommand(I18nCmd)
 }
@@ -521,53 +504,7 @@ func extractFromPath(path string, info os.FileInfo, err error, i18nStrings *map[
 	return nil
 }
 
-func cleanCmdF(command *cobra.Command, args []string) error {
-	dryRun, err := command.Flags().GetBool("dry-run")
-	if err != nil {
-		return errors.New("invalid dry-run parameter")
-	}
-	check, err := command.Flags().GetBool("check")
-	if err != nil {
-		return errors.New("invalid check parameter")
-	}
-	file, err := command.Flags().GetString("file")
-	if err != nil {
-		return errors.New("invalid file parameter")
-	}
-	enterpriseDir, err := command.Flags().GetString("enterprise-dir")
-	if err != nil {
-		return errors.New("invalid enterprise-dir parameter")
-	}
-	mattermostDir, err := command.Flags().GetString("mattermost-dir")
-	if err != nil {
-		return errors.New("invalid mattermost-dir parameter")
-	}
-	portalDir, err := command.Flags().GetString("portal-dir")
-	if err != nil {
-		return errors.New("invalid portal-dir parameter")
-	}
-	translationDir := path.Join(mattermostDir, "i18n")
-	if portalDir != "" {
-		if enterpriseDir != "" || mattermostDir != "" {
-			return errors.New("please specify EITHER portal-dir or enterprise-dir/mattermost-dir")
-		}
-		translationDir = portalDir
-	}
-
-	if filepath.Ext(file) == ".json" && file != "en.json" {
-		i, err2 := clean(translationDir, file, dryRun, check)
-		if err2 != nil {
-			return err2
-		}
-		if check {
-			log.Fatalf("%v has %v empty translations\n", file, i)
-		}
-	}
-
-	return nil
-}
-
-func cleanAllCmdF(command *cobra.Command, args []string) error {
+func cleanEmptyCmdF(command *cobra.Command, args []string) error {
 	dryRun, err := command.Flags().GetBool("dry-run")
 	if err != nil {
 		return errors.New("invalid dry-run parameter")
@@ -596,82 +533,82 @@ func cleanAllCmdF(command *cobra.Command, args []string) error {
 		translationDir = portalDir
 	}
 
-	var shippedFs []string
+	var shippedFiles []string
 	files, err := ioutil.ReadDir(translationDir)
 	if err != nil {
 		return err
 	}
-	for _, f := range files {
-		if !f.IsDir() && filepath.Ext(f.Name()) == ".json" && f.Name() != "en.json" {
-			shippedFs = append(shippedFs, f.Name())
+	for _, file := range files {
+		if !file.IsDir() && filepath.Ext(file.Name()) == ".json" && file.Name() != "en.json" {
+			shippedFiles = append(shippedFiles, file.Name())
 		}
 	}
 
-	rs := ""
-	for _, f := range shippedFs {
-		r, err2 := clean(translationDir, f, dryRun, check)
+	results := ""
+	for _, file := range shippedFiles {
+		result, err2 := clean(translationDir, file, dryRun, check)
 		if err2 != nil {
 			return err2
 		}
-		rs += *r
+		results += *result
 	}
-	if rs == "" {
+	if results == "" {
 		return nil
 	}
-	fmt.Print("\n" + rs)
+	fmt.Print("\n" + results)
 	if check {
 		os.Exit(1)
 	}
 	return nil
 }
 
-func clean(translationDir string, f string, dryRun bool, check bool) (*string, error) {
-	oldJ, err := ioutil.ReadFile(path.Join(translationDir, f))
+func clean(translationDir string, file string, dryRun bool, check bool) (*string, error) {
+	oldJSON, err := ioutil.ReadFile(path.Join(translationDir, file))
 	if err != nil {
 		return nil, err
 	}
 
-	var ts []Item
-	if err = json.Unmarshal(oldJ, &ts); err != nil {
+	var oldList []Item
+	if err = json.Unmarshal(oldJSON, &oldList); err != nil {
 		return nil, err
 	}
-	cts, i := removeEmptyTranslations(ts)
-	r := ""
-	if i == 0 {
-		return &r, nil
+	newList, count := removeEmptyTranslations(oldList)
+	result := ""
+	if count == 0 {
+		return &result, nil
 	}
-	r = fmt.Sprintf("%v has %v empty translations\n", f, i)
+	result = fmt.Sprintf("%v has %v empty translations\n", file, count)
 	if dryRun || check {
-		return &r, nil
+		return &result, nil
 	}
 
-	newJ, err := JSONMarshal(cts)
+	newJSON, err := JSONMarshal(newList)
 	if err != nil {
 		return nil, err
 	}
-	filename := path.Join(translationDir, f)
-	fi, err := os.Lstat(filename)
+	filename := path.Join(translationDir, file)
+	fileInfo, err := os.Lstat(filename)
 	if err != nil {
 		return nil, err
 	}
-	if err = ioutil.WriteFile(filename, newJ, fi.Mode().Perm()); err != nil {
+	if err = ioutil.WriteFile(filename, newJSON, fileInfo.Mode().Perm()); err != nil {
 		return nil, err
 	}
-	return &r, nil
+	return &result, nil
 }
 
-func removeEmptyTranslations(ts []Item) ([]Item, int) {
-	var k int
-	var cts []Item
-	for i, t := range ts {
+func removeEmptyTranslations(oldList []Item) ([]Item, int) {
+	var count int
+	var newList []Item
+	for i, t := range oldList {
 		if string(t.Translation) != "\"\"" {
-			cts = append(cts, ts[i])
+			newList = append(newList, oldList[i])
 		} else {
-			k++
+			count++
 		}
 
 	}
-	return cts, k
+	return newList, count
 }
 
 func JSONMarshal(t interface{}) ([]byte, error) {

--- a/mmgotool/commands/i18n.go
+++ b/mmgotool/commands/i18n.go
@@ -83,15 +83,15 @@ func init() {
 	CheckCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
 	CheckCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
 
-	CleanCmd.Flags().Bool("dry-run", false, "Whether to not apply changes")
-	CleanCmd.Flags().Bool("check", false, "Whether to throw an exit code when there are empty strings present")
+	CleanCmd.Flags().Bool("dry-run", false, "Run without applying changes")
+	CleanCmd.Flags().Bool("check", false, "Throw exit code on empty translation strings")
 	CleanCmd.Flags().String("file", "de.json", "Filename, e.g. de.json, to clean empty translation strings from")
 	CleanCmd.Flags().String("portal-dir", "../customer-web-server", "Path to folder with the Mattermost Customer Portal source code")
 	CleanCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
 	CleanCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
 
-	CleanAllCmd.Flags().Bool("dry-run", false, "Whether to not apply changes")
-	CleanAllCmd.Flags().Bool("check", false, "Whether to throw an exit code when there are empty strings present")
+	CleanAllCmd.Flags().Bool("dry-run", false, "Run without applying changes")
+	CleanAllCmd.Flags().Bool("check", false, "Throw exit code on empty translation strings")
 	CleanAllCmd.Flags().String("portal-dir", "../customer-web-server", "Path to folder with the Mattermost Customer Portal source code")
 	CleanAllCmd.Flags().String("enterprise-dir", "../enterprise", "Path to folder with the Mattermost enterprise source code")
 	CleanAllCmd.Flags().String("mattermost-dir", "./", "Path to folder with the Mattermost source code")
@@ -633,9 +633,10 @@ func clean(translationDir string, f string, dryRun bool) (*string, error) {
 	}
 	cts, i := removeEmptyTranslations(ts)
 	r := ""
-	if i > 0 {
-		r = fmt.Sprintf("%v has %v empty translations\n", f, i)
+	if i == 0 {
+	    return &r, nil
 	}
+    r = fmt.Sprintf("%v has %v empty translations\n", f, i)
 
 	if !dryRun {
 		newJ, err := JSONMarshal(cts)

--- a/mmgotool/commands/root.go
+++ b/mmgotool/commands/root.go
@@ -15,7 +15,7 @@ func Run(args []string) error {
 }
 
 var RootCmd = &cobra.Command{
-	Use:   "mmdev",
+	Use:   "mmgotool",
 	Short: "Mattermost dev utils cli",
 	Long:  `Mattermost cli to help in the development process`,
 }

--- a/mmjstool/src/i18n_handlers.js
+++ b/mmjstool/src/i18n_handlers.js
@@ -258,7 +258,7 @@ function cleanAll(fPath, dryRun, check) {
     const files = fs.readdirSync(fPath);
     let rs = '';
     for (const f of files) {
-        const r = removeItems(fPath, f, dryRun);
+        const r = removeItems(fPath, f, dryRun, check);
         rs += r;
     }
     if (rs !== '') {
@@ -271,7 +271,7 @@ function cleanAll(fPath, dryRun, check) {
     return 0;
 }
 
-export function removeItems(fPath, f, dryRun) {
+export function removeItems(fPath, f, dryRun, check) {
     if (f.split('.').pop() !== 'json' || f === 'en.json') {
         return '';
     }
@@ -287,8 +287,10 @@ export function removeItems(fPath, f, dryRun) {
     if (count === 0) {
         return '';
     }
-    if (!dryRun) {
-        fs.writeFileSync(path.join(fPath, f), JSON.stringify(obj, null, 2) + '\n');
+    const msg = f + ' has ' + count + ' empty translations\n';
+    if (dryRun || check) {
+        return msg;
     }
-    return f + ' has ' + count + ' empty translations\n';
+    fs.writeFileSync(path.join(fPath, f), JSON.stringify(obj, null, 2) + '\n');
+    return msg;
 }

--- a/mmjstool/src/i18n_handlers.js
+++ b/mmjstool/src/i18n_handlers.js
@@ -199,3 +199,97 @@ export function i18nSplit(argv) {
         }
     });
 }
+
+export function i18nClean(argv) {
+    i18nCleanWebapp(argv);
+    i18nCleanMobile(argv);
+}
+
+export function i18nCleanWebapp(argv) {
+    const webappDir = argv['webapp-dir']
+    const file = argv['file']
+    const fPath = path.join(webappDir, 'i18n')
+    const dryRun = argv['dry-run']
+    const check = argv['check']
+    const r = removeItems(fPath, file, dryRun)
+    if (r !== '') {
+        console.info(r)
+    }
+    if (check && r !== '') {
+        return process.exit(1);
+    }
+}
+
+export function i18nCleanMobile(argv) {
+    const mobileDir = argv['mobile-dir']
+    const file = argv['file']
+    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n')
+    const dryRun = argv['dry-run']
+    const check = argv['check']
+    const r = removeItems(fPath, file, dryRun)
+    if (r !== '') {
+        console.info(r)
+    }
+    if (check && r !== '') {
+        return process.exit(1);
+    }
+}
+
+export function i18nCleanAll(argv) {
+    i18nCleanAllWebapp(argv);
+    i18nCleanAllMobile(argv);
+}
+
+export function i18nCleanAllWebapp(argv) {
+    const webappDir = argv['webapp-dir']
+    const dryRun = argv['dry-run']
+    const check = argv['check']
+    const fPath = path.join(webappDir, 'i18n')
+    return cleanAll(fPath, dryRun, check);
+}
+
+export function i18nCleanAllMobile(argv) {
+    const mobileDir = argv['mobile-dir']
+    const dryRun = argv['dry-run']
+    const check = argv['check']
+    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n')
+    return cleanAll(fPath, dryRun, check);
+}
+
+function cleanAll(fPath, dryRun, check) {
+    const files = fs.readdirSync(fPath)
+    let rs = ''
+    for (const f of files) {
+        const r = removeItems(fPath, f, dryRun)
+        rs += r
+    }
+    if (rs !== '') {
+        console.info(fPath)
+        console.info(rs)
+    }
+    if (check && rs !== '') {
+        return process.exit(1);
+    }
+}
+
+export function removeItems(fPath, f, dryRun) {
+    if (f.split('.').pop() !== 'json' || f === 'en.json') {
+        return ''
+    }
+    let count = 0
+    const obj = JSON.parse(fs.readFileSync(path.join(fPath, f)).toString(), (k, v) => {
+        if (v === '') {
+            count++
+        } else {
+            return v
+        }
+    })
+
+    if (count === 0) {
+        return ''
+    }
+    if (!dryRun) {
+        fs.writeFileSync(path.join(fPath, f), JSON.stringify(obj, null, 2) + '\n')
+    }
+    return f + ' has ' + count + ' empty translations'
+}

--- a/mmjstool/src/i18n_handlers.js
+++ b/mmjstool/src/i18n_handlers.js
@@ -201,95 +201,94 @@ export function i18nSplit(argv) {
 }
 
 export function i18nClean(argv) {
-    i18nCleanWebapp(argv);
-    i18nCleanMobile(argv);
+    const wCode = i18nCleanWebapp(argv);
+    const mCode = i18nCleanMobile(argv);
+    process.exit(wCode || mCode);
 }
 
 export function i18nCleanWebapp(argv) {
-    const webappDir = argv['webapp-dir']
-    const file = argv['file']
-    const fPath = path.join(webappDir, 'i18n')
-    const dryRun = argv['dry-run']
-    const check = argv['check']
-    const r = removeItems(fPath, file, dryRun)
-    if (r !== '') {
-        console.info(r)
-    }
-    if (check && r !== '') {
-        return process.exit(1);
-    }
+    const webappDir = argv['webapp-dir'];
+    const fPath = path.join(webappDir, 'i18n');
+    return clean(argv, fPath);
 }
 
 export function i18nCleanMobile(argv) {
-    const mobileDir = argv['mobile-dir']
-    const file = argv['file']
-    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n')
-    const dryRun = argv['dry-run']
-    const check = argv['check']
-    const r = removeItems(fPath, file, dryRun)
+    const mobileDir = argv['mobile-dir'];
+    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n');
+    return clean(argv, fPath);
+}
+
+function clean(argv, fPath) {
+    const file = argv.file;
+    const dryRun = argv['dry-run'];
+    const check = argv.check;
+    const r = removeItems(fPath, file, dryRun);
     if (r !== '') {
-        console.info(r)
+        console.info(r);
     }
     if (check && r !== '') {
-        return process.exit(1);
+        return 1;
     }
+    return 0;
 }
 
 export function i18nCleanAll(argv) {
-    i18nCleanAllWebapp(argv);
-    i18nCleanAllMobile(argv);
+    const wCode = i18nCleanAllWebapp(argv);
+    const mCode = i18nCleanAllMobile(argv);
+    process.exit(wCode || mCode);
 }
 
 export function i18nCleanAllWebapp(argv) {
-    const webappDir = argv['webapp-dir']
-    const dryRun = argv['dry-run']
-    const check = argv['check']
-    const fPath = path.join(webappDir, 'i18n')
+    const webappDir = argv['webapp-dir'];
+    const dryRun = argv['dry-run'];
+    const check = argv.check;
+    const fPath = path.join(webappDir, 'i18n');
     return cleanAll(fPath, dryRun, check);
 }
 
 export function i18nCleanAllMobile(argv) {
-    const mobileDir = argv['mobile-dir']
-    const dryRun = argv['dry-run']
-    const check = argv['check']
-    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n')
+    const mobileDir = argv['mobile-dir'];
+    const dryRun = argv['dry-run'];
+    const check = argv.check;
+    const fPath = path.join(mobileDir, 'assets', 'base', 'i18n');
     return cleanAll(fPath, dryRun, check);
 }
 
 function cleanAll(fPath, dryRun, check) {
-    const files = fs.readdirSync(fPath)
-    let rs = ''
+    const files = fs.readdirSync(fPath);
+    let rs = '';
     for (const f of files) {
-        const r = removeItems(fPath, f, dryRun)
-        rs += r
+        const r = removeItems(fPath, f, dryRun);
+        rs += r;
     }
     if (rs !== '') {
-        console.info(fPath)
-        console.info(rs)
+        console.info(fPath);
+        console.info(rs);
     }
     if (check && rs !== '') {
-        return process.exit(1);
+        return 1;
     }
+    return 0;
 }
 
 export function removeItems(fPath, f, dryRun) {
     if (f.split('.').pop() !== 'json' || f === 'en.json') {
-        return ''
+        return '';
     }
-    let count = 0
+    let count = 0;
     const obj = JSON.parse(fs.readFileSync(path.join(fPath, f)).toString(), (k, v) => {
         if (v === '') {
-            count++
-        } else {
-            return v
+            count++;
+            return undefined; // eslint-disable-line no-undefined
         }
-    })
+        return v;
+    });
 
     if (count === 0) {
-        return ''
+        return '';
     }
     if (!dryRun) {
-        fs.writeFileSync(path.join(fPath, f), JSON.stringify(obj, null, 2) + '\n')
+        fs.writeFileSync(path.join(fPath, f), JSON.stringify(obj, null, 2) + '\n');
     }
-    return f + ' has ' + count + ' empty translations'
+    return f + ' has ' + count + ' empty translations\n';
 }

--- a/mmjstool/src/index.js
+++ b/mmjstool/src/index.js
@@ -72,67 +72,7 @@ const ignored = yargs.
                 () => { /* empty function */ },
                 i18nHandlers.i18nCheckWebapp,
             ).
-            command('clean',
-                'Read the translation file, find all the empty translation strings and remove the translation item',
-                (cleanArgs) => {
-                    cleanArgs.demandOption(['mobile-dir', 'webapp-dir', 'file']).
-                        option('file', {
-                            describe: 'File to remove empty translations from',
-                            default: 'de.json',
-                        }).
-                        option('check', {
-                            describe: 'Throw exit code on empty translation strings',
-                            default: false,
-                        }).
-                        option('dry-run', {
-                            describe: 'Run without applying changes',
-                            default: false,
-                        })
-                    ;
-                },
-                i18nHandlers.i18nClean,
-            ).
-            command('clean-webapp',
-                'Read the specific translation file, find all the empty translation strings and remove the translation item',
-                (cleanArgs) => {
-                    cleanArgs.demandOption(['webapp-dir', 'file']).
-                        option('file', {
-                            describe: 'File to remove empty translations from',
-                            default: 'de.json',
-                        }).
-                        option('check', {
-                            describe: 'Throw exit code on empty translation strings',
-                            default: false,
-                        }).
-                        option('dry-run', {
-                            describe: 'Run without applying changes',
-                            default: false,
-                        })
-                    ;
-                },
-                i18nHandlers.i18nCleanWebapp,
-            ).
-            command('clean-mobile',
-                'Read the specific translation file, find all the empty translation strings and remove the translation item',
-                (cleanArgs) => {
-                    cleanArgs.demandOption(['mobile-dir', 'file']).
-                        option('file', {
-                            describe: 'File to remove empty translations from',
-                            default: 'de.json',
-                        }).
-                        option('check', {
-                            describe: 'Throw exit code on empty translation strings',
-                            default: false,
-                        }).
-                        option('dry-run', {
-                            describe: 'Run without applying changes',
-                            default: false,
-                        })
-                    ;
-                },
-                i18nHandlers.i18nCleanMobile,
-            ).
-            command('clean-all',
+            command('clean-empty',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
                 (cleanAllArgs) => {
                     cleanAllArgs.demandOption('mobile-dir', 'webapp-dir').
@@ -146,9 +86,9 @@ const ignored = yargs.
                         })
                     ;
                 },
-                i18nHandlers.i18nCleanAll,
+                i18nHandlers.i18nCleanEmpty,
             ).
-            command('clean-all-webapp',
+            command('clean-empty-webapp',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
                 (cleanAllArgs) => {
                     cleanAllArgs.demandOption('webapp-dir').
@@ -162,9 +102,9 @@ const ignored = yargs.
                         })
                     ;
                 },
-                i18nHandlers.i18nCleanAllWebapp,
+                i18nHandlers.i18nCleanEmptyWebapp,
             ).
-            command('clean-all-mobile',
+            command('clean-empty-mobile',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
                 (cleanAllArgs) => {
                     cleanAllArgs.demandOption('mobile-dir').
@@ -178,7 +118,7 @@ const ignored = yargs.
                         })
                     ;
                 },
-                i18nHandlers.i18nCleanAllMobile,
+                i18nHandlers.i18nCleanEmptyMobile,
             ).
             option('webapp-dir', {
                 describe: 'webapp source code directory',

--- a/mmjstool/src/index.js
+++ b/mmjstool/src/index.js
@@ -4,7 +4,7 @@ const yargs = require('yargs');
 
 const i18nHandlers = require('./i18n_handlers');
 
-/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }],*/
 const ignored = yargs.
     usage('Usage: mmjstool <command> [options]').
     example('mmjstool i18n extract-webapp --webapp-dir ./', 'Extract all the i18n strings from the webapp source code').
@@ -74,20 +74,20 @@ const ignored = yargs.
             ).
             command('clean',
                 'Read the translation file, find all the empty translation strings and remove the translation item',
-            (cleanArgs) => {
+                (cleanArgs) => {
                     cleanArgs.demandOption(['mobile-dir', 'webapp-dir', 'file']).
-                    option('file', {
-                        describe: 'File to remove empty translations from',
-                        default: 'de.json',
-                    })
-                    .option('check', {
-                        describe: 'Throw exit code on empty translation strings',
-                        default: false,
-                    })
-                    .option('dry-run', {
-                        describe: 'Run without applying changes',
-                        default: false,
-                    })
+                        option('file', {
+                            describe: 'File to remove empty translations from',
+                            default: 'de.json',
+                        }).
+                        option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        }).
+                        option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
                     ;
                 },
                 i18nHandlers.i18nClean,
@@ -95,16 +95,16 @@ const ignored = yargs.
             command('clean-webapp',
                 'Read the specific translation file, find all the empty translation strings and remove the translation item',
                 (cleanArgs) => {
-                    cleanArgs.demandOption(['webapp-dir', 'file'])
-                        .option('file', {
+                    cleanArgs.demandOption(['webapp-dir', 'file']).
+                        option('file', {
                             describe: 'File to remove empty translations from',
                             default: 'de.json',
-                        })
-                        .option('check', {
+                        }).
+                        option('check', {
                             describe: 'Throw exit code on empty translation strings',
                             default: false,
-                        })
-                        .option('dry-run', {
+                        }).
+                        option('dry-run', {
                             describe: 'Run without applying changes',
                             default: false,
                         })
@@ -115,16 +115,16 @@ const ignored = yargs.
             command('clean-mobile',
                 'Read the specific translation file, find all the empty translation strings and remove the translation item',
                 (cleanArgs) => {
-                    cleanArgs.demandOption(['mobile-dir', 'file'])
-                        .option('file', {
+                    cleanArgs.demandOption(['mobile-dir', 'file']).
+                        option('file', {
                             describe: 'File to remove empty translations from',
                             default: 'de.json',
-                        })
-                        .option('check', {
+                        }).
+                        option('check', {
                             describe: 'Throw exit code on empty translation strings',
                             default: false,
-                        })
-                        .option('dry-run', {
+                        }).
+                        option('dry-run', {
                             describe: 'Run without applying changes',
                             default: false,
                         })
@@ -134,13 +134,13 @@ const ignored = yargs.
             ).
             command('clean-all',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
-            (cleanAllArgs) => {
-                    cleanAllArgs.demandOption('mobile-dir', 'webapp-dir')
-                        .option('check', {
+                (cleanAllArgs) => {
+                    cleanAllArgs.demandOption('mobile-dir', 'webapp-dir').
+                        option('check', {
                             describe: 'Throw exit code on empty translation strings',
                             default: false,
-                        })
-                        .option('dry-run', {
+                        }).
+                        option('dry-run', {
                             describe: 'Run without applying changes',
                             default: false,
                         })
@@ -151,12 +151,12 @@ const ignored = yargs.
             command('clean-all-webapp',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
                 (cleanAllArgs) => {
-                    cleanAllArgs.demandOption('webapp-dir')
-                        .option('check', {
+                    cleanAllArgs.demandOption('webapp-dir').
+                        option('check', {
                             describe: 'Throw exit code on empty translation strings',
                             default: false,
-                        })
-                        .option('dry-run', {
+                        }).
+                        option('dry-run', {
                             describe: 'Run without applying changes',
                             default: false,
                         })
@@ -166,13 +166,13 @@ const ignored = yargs.
             ).
             command('clean-all-mobile',
                 'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
-            (cleanAllArgs) => {
-                    cleanAllArgs.demandOption('mobile-dir')
-                        .option('check', {
+                (cleanAllArgs) => {
+                    cleanAllArgs.demandOption('mobile-dir').
+                        option('check', {
                             describe: 'Throw exit code on empty translation strings',
                             default: false,
-                        })
-                        .option('dry-run', {
+                        }).
+                        option('dry-run', {
                             describe: 'Run without applying changes',
                             default: false,
                         })

--- a/mmjstool/src/index.js
+++ b/mmjstool/src/index.js
@@ -72,6 +72,114 @@ const ignored = yargs.
                 () => { /* empty function */ },
                 i18nHandlers.i18nCheckWebapp,
             ).
+            command('clean',
+                'Read the translation file, find all the empty translation strings and remove the translation item',
+            (cleanArgs) => {
+                    cleanArgs.demandOption(['mobile-dir', 'webapp-dir', 'file']).
+                    option('file', {
+                        describe: 'File to remove empty translations from',
+                        default: 'de.json',
+                    })
+                    .option('check', {
+                        describe: 'Throw exit code on empty translation strings',
+                        default: false,
+                    })
+                    .option('dry-run', {
+                        describe: 'Run without applying changes',
+                        default: false,
+                    })
+                    ;
+                },
+                i18nHandlers.i18nClean,
+            ).
+            command('clean-webapp',
+                'Read the specific translation file, find all the empty translation strings and remove the translation item',
+                (cleanArgs) => {
+                    cleanArgs.demandOption(['webapp-dir', 'file'])
+                        .option('file', {
+                            describe: 'File to remove empty translations from',
+                            default: 'de.json',
+                        })
+                        .option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        })
+                        .option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
+                    ;
+                },
+                i18nHandlers.i18nCleanWebapp,
+            ).
+            command('clean-mobile',
+                'Read the specific translation file, find all the empty translation strings and remove the translation item',
+                (cleanArgs) => {
+                    cleanArgs.demandOption(['mobile-dir', 'file'])
+                        .option('file', {
+                            describe: 'File to remove empty translations from',
+                            default: 'de.json',
+                        })
+                        .option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        })
+                        .option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
+                    ;
+                },
+                i18nHandlers.i18nCleanMobile,
+            ).
+            command('clean-all',
+                'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
+            (cleanAllArgs) => {
+                    cleanAllArgs.demandOption('mobile-dir', 'webapp-dir')
+                        .option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        })
+                        .option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
+                    ;
+                },
+                i18nHandlers.i18nCleanAll,
+            ).
+            command('clean-all-webapp',
+                'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
+                (cleanAllArgs) => {
+                    cleanAllArgs.demandOption('webapp-dir')
+                        .option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        })
+                        .option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
+                    ;
+                },
+                i18nHandlers.i18nCleanAllWebapp,
+            ).
+            command('clean-all-mobile',
+                'Read the translation files other than the english base file, find all the empty translation strings and remove the translation item',
+            (cleanAllArgs) => {
+                    cleanAllArgs.demandOption('mobile-dir')
+                        .option('check', {
+                            describe: 'Throw exit code on empty translation strings',
+                            default: false,
+                        })
+                        .option('dry-run', {
+                            describe: 'Run without applying changes',
+                            default: false,
+                        })
+                    ;
+                },
+                i18nHandlers.i18nCleanAllMobile,
+            ).
             option('webapp-dir', {
                 describe: 'webapp source code directory',
                 default: '../mattermost-webapp',

--- a/mmjstool/src/index.js
+++ b/mmjstool/src/index.js
@@ -4,7 +4,7 @@ const yargs = require('yargs');
 
 const i18nHandlers = require('./i18n_handlers');
 
-/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }],*/
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 const ignored = yargs.
     usage('Usage: mmjstool <command> [options]').
     example('mmjstool i18n extract-webapp --webapp-dir ./', 'Extract all the i18n strings from the webapp source code').

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "eslint --ignore-pattern node_modules --ignore-pattern build --ext .js . --quiet",
     "fix": "eslint --ignore-pattern node_modules --ignore-pattern build --ext .js . --quiet --fix",
     "babel": "babel --presets @babel/env mmjstool/src/index.js mmjstool/src/i18n_extract.js mmjstool/src/i18n_handlers.js -d mmjstool/build",
+    "i18n": "babel --presets @babel/env mmjstool/src/index.js mmjstool/src/i18n_extract.js mmjstool/src/i18n_handlers.js -d mmjstool/build && node mmjstool/build/index.js i18n",
     "build": "webpack",
     "prepare": "webpack"
   },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->This is a feature to add removing empty translation strings for server/webapp/mobile, because of the following bug with weblate: https://github.com/WeblateOrg/weblate/issues/4076
I will also implement an additional check in all three pipelines using these commands. 
I additionally touched the golang code, to get to know the code and where I should put my code. During that process, I fixed some complaints my IDE had and renamed some variables for my personal understanding. If this is not appreciated, I fully understand and will revert my changes. Please let me know. 

#### PRs
https://github.com/mattermost/mattermost-mobile/pull/4718
https://github.com/mattermost/mattermost-webapp/pull/6253
https://github.com/mattermost/enterprise/pull/751

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

