### PR TITLE
Add sleep statement between each HW ticket creation

### DIFF
--- a/github_jira_tools/utils.py
+++ b/github_jira_tools/utils.py
@@ -35,6 +35,7 @@ JIRA: https://mattermost.atlassian.net/browse/{{TICKET}}
             print('------\n{}\n{}\n\n{}'.format(title, "="*len(title), description))
             continue
 
+        # Add one second sleep per https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits
         time.sleep(1)
         try:
             new_issue = r.create_issue(

--- a/github_jira_tools/utils.py
+++ b/github_jira_tools/utils.py
@@ -1,3 +1,4 @@
+import time
 import requests
 from requests.auth import HTTPBasicAuth
 from github import Github
@@ -34,6 +35,7 @@ JIRA: https://mattermost.atlassian.net/browse/{{TICKET}}
             print('------\n{}\n{}\n\n{}'.format(title, "="*len(title), description))
             continue
 
+        time.sleep(1)
         try:
             new_issue = r.create_issue(
                 title=title,


### PR DESCRIPTION
#### Summary

This PR solves an abuse rate limit issue happening with GitHub's API when creating several HW tickets at once. Per GitHub's docs, I've added a one second sleep in between each ticket creation.

As seen here https://community-daily.mattermost.com/core/pl/di6cyysfsbrfz88e6nr8cwedjw, the help wanted sync causes an abuse rate limit on GitHub's API when creating several HW tickets at once:

> Unable to create issue for jira issue MM-20381. error: 403 {'message': 'You have triggered an abuse detection mechanism and have been temporarily blocked from content creation. Please retry your request again later.', 'documentation_url': 'https://docs.github.com/overview/resources-in-the-rest-api#abuse-rate-limits'}

According to https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits:

> If you're making a large number of `POST`, `PATCH`, `PUT`, or `DELETE` requests for a single user or client ID, wait at least one second between each request.