### PR TITLE
Ignore CodeQL analysis on bin/mmjstool file

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths-ignore:
+      - 'bin'    
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
#### Summary
Ignore CodeQL analysis on `bin/mmjstool` file. CodeQL checks on `bin/mmjstool` file is often not helpful as it is a composite of multiple files including libraries and is often false positive. 


#### Ticket Link
N/A