### PR TITLE
MM-46577: Add support for adding untranslated keys

### DIFF
--- a/mmgotool/commands/i18n.go
+++ b/mmgotool/commands/i18n.go
@@ -22,6 +22,7 @@ import (
 )
 
 const enterpriseKeyPrefix = "ent."
+const untranslatedKey = "<untranslated>"
 
 type Translation struct {
 	Id          string      `json:"id"`
@@ -117,7 +118,7 @@ func extractSrcStrings(enterpriseDir, mattermostDir, portalDir string) map[strin
 		if strings.HasPrefix(p, path.Join(mattermostDir, "vendor")) {
 			return nil
 		}
-		return extractFromPath(p, info, err, &i18nStrings)
+		return extractFromPath(p, info, err, i18nStrings)
 	}
 	if portalDir != "" {
 		_ = filepath.Walk(portalDir, walkFunc)
@@ -159,8 +160,10 @@ func extractCmdF(command *cobra.Command, args []string) error {
 	}
 	i18nStrings := extractSrcStrings(enterpriseDir, mattermostDir, portalDir)
 	if !skipDynamic {
-		addDynamicallyGeneratedStrings(&i18nStrings)
+		addDynamicallyGeneratedStrings(i18nStrings)
 	}
+	// Delete any untranslated keys
+	delete(i18nStrings, untranslatedKey)
 	var i18nStringsList []string
 	for id := range i18nStrings {
 		i18nStringsList = append(i18nStringsList, id)
@@ -247,8 +250,10 @@ func checkCmdF(command *cobra.Command, args []string) error {
 	}
 	extractedSrcStrings := extractSrcStrings(enterpriseDir, mattermostDir, portalDir)
 	if !skipDynamic {
-		addDynamicallyGeneratedStrings(&extractedSrcStrings)
+		addDynamicallyGeneratedStrings(extractedSrcStrings)
 	}
+	// Delete any untranslated keys
+	delete(extractedSrcStrings, untranslatedKey)
 	var extractedList []string
 	for id := range extractedSrcStrings {
 		extractedList = append(extractedList, id)
@@ -289,49 +294,49 @@ func checkCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func addDynamicallyGeneratedStrings(i18nStrings *map[string]bool) {
-	(*i18nStrings)["model.user.is_valid.pwd.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_number.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_number_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_uppercase.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_uppercase_number.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_uppercase_number_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_lowercase_uppercase_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_number.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_number_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_uppercase.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_uppercase_number.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_uppercase_number_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.pwd_uppercase_symbol.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.id.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.create_at.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.update_at.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.username.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.email.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.nickname.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.position.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.first_name.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.last_name.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.auth_data.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.auth_data_type.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.auth_data_pwd.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.password_limit.app_error"] = true
-	(*i18nStrings)["model.user.is_valid.locale.app_error"] = true
-	(*i18nStrings)["January"] = true
-	(*i18nStrings)["February"] = true
-	(*i18nStrings)["March"] = true
-	(*i18nStrings)["April"] = true
-	(*i18nStrings)["May"] = true
-	(*i18nStrings)["June"] = true
-	(*i18nStrings)["July"] = true
-	(*i18nStrings)["August"] = true
-	(*i18nStrings)["September"] = true
-	(*i18nStrings)["October"] = true
-	(*i18nStrings)["November"] = true
-	(*i18nStrings)["December"] = true
+func addDynamicallyGeneratedStrings(i18nStrings map[string]bool) {
+	i18nStrings["model.user.is_valid.pwd.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_number.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_number_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_uppercase.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_uppercase_number.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_uppercase_number_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_lowercase_uppercase_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_number.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_number_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_uppercase.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_uppercase_number.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_uppercase_number_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.pwd_uppercase_symbol.app_error"] = true
+	i18nStrings["model.user.is_valid.id.app_error"] = true
+	i18nStrings["model.user.is_valid.create_at.app_error"] = true
+	i18nStrings["model.user.is_valid.update_at.app_error"] = true
+	i18nStrings["model.user.is_valid.username.app_error"] = true
+	i18nStrings["model.user.is_valid.email.app_error"] = true
+	i18nStrings["model.user.is_valid.nickname.app_error"] = true
+	i18nStrings["model.user.is_valid.position.app_error"] = true
+	i18nStrings["model.user.is_valid.first_name.app_error"] = true
+	i18nStrings["model.user.is_valid.last_name.app_error"] = true
+	i18nStrings["model.user.is_valid.auth_data.app_error"] = true
+	i18nStrings["model.user.is_valid.auth_data_type.app_error"] = true
+	i18nStrings["model.user.is_valid.auth_data_pwd.app_error"] = true
+	i18nStrings["model.user.is_valid.password_limit.app_error"] = true
+	i18nStrings["model.user.is_valid.locale.app_error"] = true
+	i18nStrings["January"] = true
+	i18nStrings["February"] = true
+	i18nStrings["March"] = true
+	i18nStrings["April"] = true
+	i18nStrings["May"] = true
+	i18nStrings["June"] = true
+	i18nStrings["July"] = true
+	i18nStrings["August"] = true
+	i18nStrings["September"] = true
+	i18nStrings["October"] = true
+	i18nStrings["November"] = true
+	i18nStrings["December"] = true
 }
 
 func extractByFuncName(name string, args []ast.Expr) *string {
@@ -451,7 +456,7 @@ func extractForConstants(name string, valueNode ast.Expr) *string {
 
 }
 
-func extractFromPath(path string, info os.FileInfo, err error, i18nStrings *map[string]bool) error {
+func extractFromPath(path string, info os.FileInfo, err error, i18nStrings map[string]bool) error {
 	if strings.HasSuffix(path, "model/client4.go") {
 		return nil
 	}
@@ -512,7 +517,7 @@ func extractFromPath(path string, info os.FileInfo, err error, i18nStrings *map[
 					if id == nil {
 						continue
 					}
-					(*i18nStrings)[strings.Trim(*id, "\"")] = true
+					i18nStrings[strings.Trim(*id, "\"")] = true
 				}
 			}
 			return true
@@ -521,7 +526,7 @@ func extractFromPath(path string, info os.FileInfo, err error, i18nStrings *map[
 		}
 
 		if id != nil {
-			(*i18nStrings)[strings.Trim(*id, "\"")] = true
+			i18nStrings[strings.Trim(*id, "\"")] = true
 		}
 
 		return true


### PR DESCRIPTION
We have a requirement to be able to create
error messages which are just meant to be logged on server
and not translated.

However, the current model.AppError logic mandates an error id
which always must have a translation attached to it.

We circumvent this by adding a dummy id which is ignored by the
tool when looking for strings. Any code needing to create an
error without a translation can just use the dummy id.

While here, we remove pointers to a map :)

https://mattermost.atlassian.net/browse/MM-46577