### PR TITLE
Remove setup via CLI tool

### DIFF
--- a/pluginops/repo.go
+++ b/pluginops/repo.go
@@ -1,13 +1,6 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"time"
-
-	"github.com/google/go-github/v32/github"
-	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -44,106 +37,10 @@ var setupCommunityCmd = &cobra.Command{
 
 		repo := args[0]
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		repoSettings := &github.Repository{
-			Private: github.Bool(true),
-
-			AllowMergeCommit: github.Bool(true),
-			AllowRebaseMerge: github.Bool(false),
-			AllowSquashMerge: github.Bool(true),
-
-			HasIssues:   github.Bool(false),
-			HasWiki:     github.Bool(false),
-			HasPages:    github.Bool(false),
-			HasProjects: github.Bool(false),
-		}
-		_, _, err = client.Repositories.Edit(ctx, org, repo, repoSettings)
-		if err != nil {
-			log.WithField("repo", repo).WithError(err).Error("Failed to update repository")
-			return
-		}
-
-		log.Info("Successfully updated repository settings")
-
-		permssionPush := &github.RepositoryAddCollaboratorOptions{
-			Permission: "push",
-		}
-
-		_, _, err = client.Repositories.AddCollaborator(ctx, org, repo, mattermostBuild, permssionPush)
-		if err != nil {
-			log.WithField("repo", repo).WithError(err).Errorf("Failed add %s to repo", mattermostBuild)
-			return
-		}
-
-		permssionTriage := &github.TeamAddTeamRepoOptions{
-			Permission: "triage",
-		}
-
-		_, err = client.Teams.AddTeamRepoBySlug(ctx, org, integrationsTeamSlug, org, repo, permssionTriage)
-		if err != nil {
-			log.WithField("repo", repo).WithError(err).Errorf("Failed add %s to repo", integrationsTeamSlug)
-			return
-		}
-
-		_, err = client.Teams.AddTeamRepoBySlug(ctx, org, securityionsTeamSlug, org, repo, permssionTriage)
-		if err != nil {
-			log.WithField("repo", repo).WithError(err).Errorf("Failed add %s to repo", securityionsTeamSlug)
-			return
-		}
-
-		log.Info("Successfully added needed permissions")
-
 		log.Info("Cleaning up existing labels")
 		removeAllLabels(client, repo)
 
 		log.Info("Setting up new labels")
 		createOrUpdateLabels(client, repo, communityPlugins)
-
-		for {
-			prompt := promptui.Prompt{
-				Label:     "Do want to add a Collaborator to the repo",
-				IsConfirm: true,
-			}
-			_, err := prompt.Run()
-			if err != nil {
-				if errors.Is(err, promptui.ErrAbort) {
-					break
-				}
-
-				log.WithField("repo", repo).WithError(err).Error("Prompt failed")
-				return
-			}
-
-			prompt = promptui.Prompt{
-				Label: "Which Collaborator do you want to add?",
-			}
-
-			user, err := prompt.Run()
-			if err != nil {
-				log.WithField("repo", repo).WithError(err).Error("Prompt failed")
-				return
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			_, _, err = client.Users.Get(ctx, user)
-			if err != nil {
-				fmt.Printf("\nUser %s doesn't exist\n", user)
-				continue
-			}
-
-			_, _, err = client.Repositories.AddCollaborator(ctx, org, repo, user, &github.RepositoryAddCollaboratorOptions{
-				Permission: "pull",
-			})
-			if err != nil {
-				log.WithField("repo", repo).WithError(err).Errorf("Failed add %s to repo", user)
-				continue
-			}
-
-			fmt.Printf("Successfully added %s to the repo\n", user)
-		}
 	},
 }


### PR DESCRIPTION
#### Summary
Most repository configuration is now in https://git.internal.mattermost.com/ops/github-management. Setting up a repo should not happen via CLI

#### Ticket Link
None