### PR TITLE
MM-3943 : Update mmgotool to handle go-i18n 2.X migration

### DIFF
--- a/mmgotool/commands/i18n.go
+++ b/mmgotool/commands/i18n.go
@@ -665,10 +665,9 @@ func clean(translationDir string, file string, dryRun bool, check bool) (*string
 	}
 	newList, count := removeEmptyTranslations(oldList)
 	result := ""
-	if count == 0 {
-		return &result, nil
+	if count != 0 {
+		result = fmt.Sprintf("%v has %v empty translations\n", file, count)
 	}
-	result = fmt.Sprintf("%v has %v empty translations\n", file, count)
 	if dryRun || check {
 		return &result, nil
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Modifications to mmgotool needed for PR https://github.com/mattermost/mattermost-server/pull/21327

Previously the tool seemed to ignore space only (i.e. `" "`) translations but that didn't seem right so I've changed the behavior.
I've also updated the json format to use 2 space indentation to reflect current json format used in mattermost-server

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/5267
Fixes https://mattermost.atlassian.net/browse/MM-3943