### PR TITLE
Add --yes and --releaseType flags to release command

### DIFF
--- a/pluginops/release.go
+++ b/pluginops/release.go
@@ -29,7 +29,7 @@ var (
 
 func init() {
 	bumpVersionCmd.Flags().BoolVarP(&yes, "yes", "y", false, "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively.")
-	bumpVersionCmd.Flags().StringVar(&releaseType, "releaseType", "", "Define the kind of releaese to cut. Valid options are \"major\", \"minor\" and \"patch\".")
+	bumpVersionCmd.Flags().StringVar(&releaseType, "releaseType", "", "Define the kind of release to cut. Valid options are \"major\", \"minor\" and \"patch\".")
 
 	rootCmd.AddCommand(bumpVersionCmd)
 }

--- a/pluginops/release.go
+++ b/pluginops/release.go
@@ -61,7 +61,7 @@ func releaseVersion() error {
 	}
 
 	if releaseType != "" && releaseType != "major" && releaseType != "minor" && releaseType != "patch" {
-		return errors.New("releaseType must be either of \"major\", \"minor\" and \"patch\".")
+		return errors.New("releaseType must be either \"major\", \"minor\" or \"patch\".")
 	}
 
 	log.Info("Checking if repository is clean")


### PR DESCRIPTION
#### Summary
Add two new flags to the release command:
- `-y` will assume the answer to all props is `yes`
- `--releaseType` allows users to get the release type via the CLI and therefore makes the release command scriptable.

#### Ticket Link
None