### PR TITLE
[MM-55407] Remove LocalizedIcon support from extraction utility

### DIFF
--- a/mmjstool/src/i18n_extract.js
+++ b/mmjstool/src/i18n_extract.js
@@ -10,7 +10,6 @@ import * as FileHound from 'filehound';
 const translatableComponents = {
     FormattedMessage: [{id: 'id', default: 'defaultMessage'}],
     FormattedMarkdownMessage: [{id: 'id', default: 'defaultMessage'}],
-    LocalizedIcon: ['title'],
 
     // Used in mattermost-mobile exclusively
     FormattedText: [{id: 'id', default: 'defaultMessage'}],


### PR DESCRIPTION
#### Summary
Removed support for LocalizedIcon from mmjstool

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55407

